### PR TITLE
feat: :sparkles: enable graphql introspection

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,7 @@ const main = async (): Promise<void> => {
     schema: await buildSchema({
       resolvers: [FeeResolver, FeeHistoryResolver, RateResolver],
     }),
+    introspection: true,
     plugins: [
       process.env.NODE_ENV === 'production'
         ? ApolloServerPluginLandingPageProductionDefault({ footer: false })


### PR DESCRIPTION
Enable GraphQL introspection in production to allow schema generation from separate frontend. This is usually not recommended as it introduces security risks but it's ok in this case because we're not dealing with sensitive data.