### PR TITLE
feat: :sparkles: trigger ISR on frontend

### DIFF
--- a/src/workers/save-new-fees.ts
+++ b/src/workers/save-new-fees.ts
@@ -1,3 +1,4 @@
+import axios from 'axios'
 import { getConnection } from 'typeorm'
 import { Fee } from '../entities'
 import { getFeeTable } from '../utils'
@@ -14,6 +15,12 @@ const saveNewFees = async (): Promise<void> => {
       .into(Fee)
       .values(feeTable)
       .execute()
+
+    const { status } = await axios.get('https://whatthefiatfee.vercel.app/')
+
+    if (status === 200) {
+      console.log('trigger Incremental Static Regeneration on frontend')
+    }
   }
 }
 


### PR DESCRIPTION
After updating the fee data, we send a `get` request to the frontend (whatthefiatfee.vercel.app) to trigger ISR so the next visitor sees the latest data. 

Close #7 