### PR TITLE
feat: :sparkles: trigger isr for fee history

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,6 @@
   "editor.formatOnSave": false,
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true
-  }
+  },
+  "editor.bracketPairColorization.enabled": true
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,3 @@
 export { default as getRates } from './get-rates'
 export { default as getFeeTable } from './get-fee-table'
+export { default as triggerIsr } from './trigger-isr'

--- a/src/utils/trigger-isr.ts
+++ b/src/utils/trigger-isr.ts
@@ -1,0 +1,11 @@
+import axios from 'axios'
+
+const triggerIsr = async (url: string): Promise<void> => {
+  const { status } = await axios.get(url)
+
+  if (status === 200) {
+    console.log('requesting Incremental Static Regeneration on frontend')
+  }
+}
+
+export default triggerIsr

--- a/src/workers/save-fee-history.ts
+++ b/src/workers/save-fee-history.ts
@@ -1,5 +1,6 @@
 import { getConnection } from 'typeorm'
 import { Fee, FeeHistory, Rate } from '../entities'
+import { triggerIsr } from '../utils'
 
 const saveFeeHistory = async (): Promise<void> => {
   const { eur, gbp, usd } = await Rate.findOneOrFail()
@@ -20,6 +21,8 @@ const saveFeeHistory = async (): Promise<void> => {
     .into(FeeHistory)
     .values({ eur, gbp, usd, maxFee, midFee, minFee })
     .execute()
+
+  await triggerIsr('https://whatthefiatfee.vercel.app/history/')
 }
 
 export default saveFeeHistory

--- a/src/workers/save-new-fees.ts
+++ b/src/workers/save-new-fees.ts
@@ -1,7 +1,6 @@
-import axios from 'axios'
 import { getConnection } from 'typeorm'
 import { Fee } from '../entities'
-import { getFeeTable } from '../utils'
+import { getFeeTable, triggerIsr } from '../utils'
 
 const saveNewFees = async (): Promise<void> => {
   const feeTable = await getFeeTable()
@@ -16,11 +15,7 @@ const saveNewFees = async (): Promise<void> => {
       .values(feeTable)
       .execute()
 
-    const { status } = await axios.get('https://whatthefiatfee.vercel.app/')
-
-    if (status === 200) {
-      console.log('trigger Incremental Static Regeneration on frontend')
-    }
+    await triggerIsr('https://whatthefiatfee.vercel.app/')
   }
 }
 


### PR DESCRIPTION
Refactors request to frontend as `triggerIsr` function. Adds a request to frontend when saving fee history to trigger incremental static regeneration for `history` page.

Unrelated change: Add bracket pair colorization to editor settings.